### PR TITLE
fix: set the resnpose body to non-nil

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -33,7 +33,7 @@ steps:
   commands:
   - sh scripts/durl.sh
 - name: download go modules
-  image: &image_go golang:1.12.6
+  image: &image_go golang:1.12.9
   commands:
   - go mod download
   environment:
@@ -47,7 +47,7 @@ steps:
     GO111MODULE: on
     GOPATH: /go
 - name: codecov
-  image: golang:1.12.6
+  image: *image_go
   commands:
   # bash and cgo seem to be required
   - bash scripts/codecov-test.sh

--- a/.durl.yml
+++ b/.durl.yml
@@ -5,4 +5,5 @@ ignore_urls:
 - https://codecov.io/bash  # sometimes returns 503
 ignore_hosts:
 - hello.example.com
+- goreportcard.com
 max_failed_request_count: -1

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-export GO111MODULE=on

--- a/flute/matcher.go
+++ b/flute/matcher.go
@@ -29,7 +29,7 @@ func isMatch(req *http.Request, matcher *Matcher) (bool, error) {
 		}
 	}
 	if matcher.Method != "" {
-		if strings.ToUpper(matcher.Method) != strings.ToUpper(req.Method) {
+		if !strings.EqualFold(matcher.Method, req.Method) {
 			return false, nil
 		}
 	}

--- a/flute/response.go
+++ b/flute/response.go
@@ -31,6 +31,15 @@ func createHTTPResponse(req *http.Request, resp *Response) (*http.Response, erro
 	if len(resp.Header) != 0 {
 		r.Header = resp.Header
 	}
+	if body == nil {
+		// https://golang.org/pkg/net/http/#Response
+		// The http Client and Transport guarantee that Body is always
+		// non-nil, even on responses without a body or responses with
+		// a zero-length body. It is the caller's responsibility to
+		// close Body.
+		body = ioutil.NopCloser(strings.NewReader(""))
+	}
+
 	r.Body = body
 	return &r, nil
 }


### PR DESCRIPTION
https://golang.org/pkg/net/http/#Response

> The http Client and Transport guarantee that Body is always non-nil,
> even on responses without a body or responses with a zero-length body.