### PR TITLE
fix: response's status code can't be set

### DIFF
--- a/flute/response.go
+++ b/flute/response.go
@@ -28,9 +28,6 @@ func createHTTPResponse(req *http.Request, resp *Response) (*http.Response, erro
 	if resp.BodyString != "" {
 		body = ioutil.NopCloser(strings.NewReader(resp.BodyString))
 	}
-	if len(resp.Header) != 0 {
-		r.Header = resp.Header
-	}
 	if body == nil {
 		// https://golang.org/pkg/net/http/#Response
 		// The http Client and Transport guarantee that Body is always

--- a/flute/response_test.go
+++ b/flute/response_test.go
@@ -31,11 +31,13 @@ func Test_createHTTPResponse(t *testing.T) {
 			title: "body json isn't nil",
 			req:   &http.Request{},
 			resp: &Response{
+				Base: http.Response{
+					Header: http.Header{
+						"FOO": []string{"foo"},
+					},
+				},
 				BodyJSON: map[string]interface{}{
 					"foo": "bar",
-				},
-				Header: http.Header{
-					"FOO": []string{"foo"},
 				},
 			},
 			exp: &http.Response{

--- a/flute/struct.go
+++ b/flute/struct.go
@@ -97,15 +97,11 @@ type (
 		Base http.Response
 		// If Response isn't nil, Response is called to return the response and other parameters are ignored.
 		Response func(req *http.Request) (*http.Response, error)
-		// StatusCode is the response's status code.
-		StatusCode int
 		// BodyJSON is marshaled to JSON and used as the response body.
 		// BodyJSON and BodyString should only be set to one or the other.
 		BodyJSON interface{}
 		// BodyString is the response body.
 		// BodyJSON and BodyString should only be set to one or the other.
 		BodyString string
-		// Header is the response headers.
-		Header http.Header
 	}
 )


### PR DESCRIPTION
BREAKING CHANGE: remove Response's fields StatusCode and Heaader

Use Respnse.Base's StatusCode and Header.