### PR TITLE
perf: change pointer to struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The goal is
 * Test request parameters such as the request path, headers and body
 * Mock the HTTP server
 
-`*flute.Transport` implements [http.RoundTripper](https://golang.org/pkg/net/http/#RoundTripper).
+`flute.Transport` implements [http.RoundTripper](https://golang.org/pkg/net/http/#RoundTripper).
 
 `flute` uses [testify](https://github.com/stretchr/testify)'s assert internally.
 You can test the http request parameters with assert.

--- a/examples/create_user_test.go
+++ b/examples/create_user_test.go
@@ -13,7 +13,7 @@ func TestClient_CreateUser(t *testing.T) {
 	client := &Client{
 		Token: token,
 		HTTPClient: &http.Client{
-			Transport: &flute.Transport{
+			Transport: flute.Transport{
 				T: t,
 				Services: []flute.Service{
 					{
@@ -21,7 +21,7 @@ func TestClient_CreateUser(t *testing.T) {
 						Routes: []flute.Route{
 							{
 								Name: "create a user",
-								Matcher: &flute.Matcher{
+								Matcher: flute.Matcher{
 									Method: "POST",
 									Path:   "/users",
 								},
@@ -34,7 +34,7 @@ func TestClient_CreateUser(t *testing.T) {
 										"Authorization": []string{"token " + token},
 									},
 								},
-								Response: &flute.Response{
+								Response: flute.Response{
 									Base: http.Response{
 										StatusCode: 201,
 									},
@@ -51,7 +51,7 @@ func TestClient_CreateUser(t *testing.T) {
 			},
 		},
 	}
-	user, _, err := client.CreateUser(&User{
+	user, _, err := client.CreateUser(&User{ //nolint:bodyclose
 		Name:  "foo",
 		Email: "foo@example.com",
 	})

--- a/examples/create_user_test.go
+++ b/examples/create_user_test.go
@@ -1,4 +1,4 @@
-package examples
+package examples //nolint:testpackage
 
 import (
 	"net/http"
@@ -25,7 +25,7 @@ func TestClient_CreateUser(t *testing.T) {
 									Method: "POST",
 									Path:   "/users",
 								},
-								Tester: &flute.Tester{
+								Tester: flute.Tester{
 									BodyJSONString: `{
 										  "name": "foo",
 										  "email": "foo@example.com"

--- a/flute/example_test.go
+++ b/flute/example_test.go
@@ -12,7 +12,7 @@ import (
 
 func Example_simpleMock() {
 	http.DefaultClient = &http.Client{
-		Transport: &flute.Transport{
+		Transport: flute.Transport{
 			// if *testing.T isn't given, the transport is a just mock and doesn't run the test.
 			// T: t,
 			Services: []flute.Service{
@@ -21,14 +21,14 @@ func Example_simpleMock() {
 					Routes: []flute.Route{
 						{
 							Name: "get a user",
-							Matcher: &flute.Matcher{
+							Matcher: flute.Matcher{
 								Method: "GET",
 								Path:   "/users",
 								Query: url.Values{
 									"id": []string{"10"},
 								},
 							},
-							Response: &flute.Response{
+							Response: flute.Response{
 								Base: http.Response{
 									StatusCode: 201,
 								},

--- a/flute/matcher.go
+++ b/flute/matcher.go
@@ -30,9 +30,13 @@ func matchHeader(req *http.Request, matcher Matcher) (bool, error) {
 	return matcher.Header == nil || reflect.DeepEqual(matcher.Header, req.Header), nil
 }
 
+func matchQuery(req *http.Request, matcher Matcher) (bool, error) {
+	return matcher.Query == nil || reflect.DeepEqual(matcher.Query, req.URL.Query()), nil
+}
+
 var matchFuncs = [...]matchFunc{ //nolint:gochecknoglobals
 	matchPath, matchMethod, isMatchBodyString, isMatchBodyJSON, isMatchBodyJSONString,
-	isMatchPartOfHeader, matchHeader, isMatchPartOfQuery,
+	isMatchPartOfHeader, matchHeader, isMatchPartOfQuery, matchQuery,
 }
 
 // isMatch returns whether the request matches with the matcher.
@@ -41,11 +45,6 @@ func isMatch(req *http.Request, matcher Matcher) (bool, error) {
 	for _, match := range matchFuncs {
 		if f, err := match(req, matcher); err != nil || !f {
 			return f, err
-		}
-	}
-	if matcher.Query != nil {
-		if !reflect.DeepEqual(matcher.Query, req.URL.Query()) {
-			return false, nil
 		}
 	}
 	if matcher.Match != nil {

--- a/flute/matcher.go
+++ b/flute/matcher.go
@@ -26,9 +26,13 @@ func matchMethod(req *http.Request, matcher Matcher) (bool, error) {
 	return matcher.Method == "" || strings.EqualFold(matcher.Method, req.Method), nil
 }
 
+func matchHeader(req *http.Request, matcher Matcher) (bool, error) {
+	return matcher.Header == nil || reflect.DeepEqual(matcher.Header, req.Header), nil
+}
+
 var matchFuncs = [...]matchFunc{ //nolint:gochecknoglobals
 	matchPath, matchMethod, isMatchBodyString, isMatchBodyJSON, isMatchBodyJSONString,
-	isMatchPartOfHeader,
+	isMatchPartOfHeader, matchHeader,
 }
 
 // isMatch returns whether the request matches with the matcher.
@@ -37,11 +41,6 @@ func isMatch(req *http.Request, matcher Matcher) (bool, error) {
 	for _, match := range matchFuncs {
 		if f, err := match(req, matcher); err != nil || !f {
 			return f, err
-		}
-	}
-	if matcher.Header != nil {
-		if !reflect.DeepEqual(matcher.Header, req.Header) {
-			return false, nil
 		}
 	}
 	if matcher.PartOfQuery != nil {

--- a/flute/matcher.go
+++ b/flute/matcher.go
@@ -12,17 +12,13 @@ import (
 
 // isMatchService returns whether the request matches with the service.
 // isMatchService checks the request URL.Scheme and URL.Host are equal to the service endpoint.
-func isMatchService(req *http.Request, service *Service) bool {
+func isMatchService(req *http.Request, service Service) bool {
 	return req.URL.Scheme+"://"+req.URL.Host == service.Endpoint
 }
 
 // isMatch returns whether the request matches with the matcher.
 // If the matcher has multiple conditions, IsMatch returns true if the request meets all conditions.
-func isMatch(req *http.Request, matcher *Matcher) (bool, error) { //nolint:gocognit
-	if matcher == nil {
-		// SPEC if the matcher is nil, the route matches the request.
-		return true, nil
-	}
+func isMatch(req *http.Request, matcher Matcher) (bool, error) { //nolint:gocognit
 	if matcher.Path != "" {
 		if matcher.Path != req.URL.Path {
 			return false, nil
@@ -80,7 +76,7 @@ func isMatch(req *http.Request, matcher *Matcher) (bool, error) { //nolint:gocog
 	return true, nil
 }
 
-func isMatchPartOfHeader(req *http.Request, matcher *Matcher) bool {
+func isMatchPartOfHeader(req *http.Request, matcher Matcher) bool {
 	for k, v := range matcher.PartOfHeader {
 		a, ok := req.Header[k]
 		if !ok {
@@ -95,7 +91,7 @@ func isMatchPartOfHeader(req *http.Request, matcher *Matcher) bool {
 	return true
 }
 
-func isMatchPartOfQuery(req *http.Request, matcher *Matcher) bool {
+func isMatchPartOfQuery(req *http.Request, matcher Matcher) bool {
 	query := req.URL.Query()
 	for k, v := range matcher.PartOfQuery {
 		a, ok := query[k]
@@ -111,7 +107,7 @@ func isMatchPartOfQuery(req *http.Request, matcher *Matcher) bool {
 	return true
 }
 
-func isMatchBodyString(req *http.Request, matcher *Matcher) (bool, error) {
+func isMatchBodyString(req *http.Request, matcher Matcher) (bool, error) {
 	if req.Body == nil {
 		return false, nil
 	}
@@ -125,7 +121,7 @@ func isMatchBodyString(req *http.Request, matcher *Matcher) (bool, error) {
 	return true, nil
 }
 
-func isMatchBodyJSONString(req *http.Request, matcher *Matcher) (bool, error) {
+func isMatchBodyJSONString(req *http.Request, matcher Matcher) (bool, error) {
 	if req.Body == nil {
 		return false, nil
 	}
@@ -136,7 +132,7 @@ func isMatchBodyJSONString(req *http.Request, matcher *Matcher) (bool, error) {
 	return jsoneq.Equal(b, []byte(matcher.BodyJSONString))
 }
 
-func isMatchBodyJSON(req *http.Request, matcher *Matcher) (bool, error) {
+func isMatchBodyJSON(req *http.Request, matcher Matcher) (bool, error) {
 	if req.Body == nil {
 		return false, nil
 	}

--- a/flute/matcher.go
+++ b/flute/matcher.go
@@ -22,8 +22,12 @@ func matchPath(req *http.Request, matcher Matcher) (bool, error) {
 	return matcher.Path == "" || matcher.Path == req.URL.Path, nil
 }
 
+func matchMethod(req *http.Request, matcher Matcher) (bool, error) {
+	return matcher.Method == "" || strings.EqualFold(matcher.Method, req.Method), nil
+}
+
 var matchFuncs = [...]matchFunc{ //nolint:gochecknoglobals
-	matchPath,
+	matchPath, matchMethod,
 }
 
 // isMatch returns whether the request matches with the matcher.
@@ -32,11 +36,6 @@ func isMatch(req *http.Request, matcher Matcher) (bool, error) { //nolint:gocogn
 	for _, match := range matchFuncs {
 		if f, err := match(req, matcher); err != nil || !f {
 			return f, err
-		}
-	}
-	if matcher.Method != "" {
-		if !strings.EqualFold(matcher.Method, req.Method) {
-			return false, nil
 		}
 	}
 	if matcher.BodyString != "" {

--- a/flute/matcher.go
+++ b/flute/matcher.go
@@ -27,7 +27,7 @@ func matchMethod(req *http.Request, matcher Matcher) (bool, error) {
 }
 
 var matchFuncs = [...]matchFunc{ //nolint:gochecknoglobals
-	matchPath, matchMethod, isMatchBodyString, isMatchBodyJSON,
+	matchPath, matchMethod, isMatchBodyString, isMatchBodyJSON, isMatchBodyJSONString,
 }
 
 // isMatch returns whether the request matches with the matcher.
@@ -35,12 +35,6 @@ var matchFuncs = [...]matchFunc{ //nolint:gochecknoglobals
 func isMatch(req *http.Request, matcher Matcher) (bool, error) {
 	for _, match := range matchFuncs {
 		if f, err := match(req, matcher); err != nil || !f {
-			return f, err
-		}
-	}
-	if matcher.BodyJSONString != "" {
-		f, err := isMatchBodyJSONString(req, matcher)
-		if err != nil || !f {
 			return f, err
 		}
 	}
@@ -119,6 +113,9 @@ func isMatchBodyString(req *http.Request, matcher Matcher) (bool, error) {
 }
 
 func isMatchBodyJSONString(req *http.Request, matcher Matcher) (bool, error) {
+	if matcher.BodyJSONString == "" {
+		return true, nil
+	}
 	if req.Body == nil {
 		return false, nil
 	}

--- a/flute/matcher.go
+++ b/flute/matcher.go
@@ -35,8 +35,8 @@ func matchQuery(req *http.Request, matcher Matcher) (bool, error) {
 }
 
 var matchFuncs = [...]matchFunc{ //nolint:gochecknoglobals
-	matchPath, matchMethod, isMatchBodyString, isMatchBodyJSON, isMatchBodyJSONString,
-	isMatchPartOfHeader, matchHeader, isMatchPartOfQuery, matchQuery,
+	matchPath, matchMethod, matchBodyString, matchBodyJSON, matchBodyJSONString,
+	matchPartOfHeader, matchHeader, matchPartOfQuery, matchQuery,
 }
 
 // isMatch returns whether the request matches with the matcher.
@@ -56,7 +56,7 @@ func isMatch(req *http.Request, matcher Matcher) (bool, error) {
 	return true, nil
 }
 
-func isMatchPartOfHeader(req *http.Request, matcher Matcher) (bool, error) {
+func matchPartOfHeader(req *http.Request, matcher Matcher) (bool, error) {
 	for k, v := range matcher.PartOfHeader {
 		a, ok := req.Header[k]
 		if !ok {
@@ -71,7 +71,7 @@ func isMatchPartOfHeader(req *http.Request, matcher Matcher) (bool, error) {
 	return true, nil
 }
 
-func isMatchPartOfQuery(req *http.Request, matcher Matcher) (bool, error) {
+func matchPartOfQuery(req *http.Request, matcher Matcher) (bool, error) {
 	if matcher.PartOfQuery == nil {
 		return true, nil
 	}
@@ -90,7 +90,7 @@ func isMatchPartOfQuery(req *http.Request, matcher Matcher) (bool, error) {
 	return true, nil
 }
 
-func isMatchBodyString(req *http.Request, matcher Matcher) (bool, error) {
+func matchBodyString(req *http.Request, matcher Matcher) (bool, error) {
 	if matcher.BodyString == "" {
 		return true, nil
 	}
@@ -104,7 +104,7 @@ func isMatchBodyString(req *http.Request, matcher Matcher) (bool, error) {
 	return matcher.BodyString == string(b), nil
 }
 
-func isMatchBodyJSONString(req *http.Request, matcher Matcher) (bool, error) {
+func matchBodyJSONString(req *http.Request, matcher Matcher) (bool, error) {
 	if matcher.BodyJSONString == "" {
 		return true, nil
 	}
@@ -118,7 +118,7 @@ func isMatchBodyJSONString(req *http.Request, matcher Matcher) (bool, error) {
 	return jsoneq.Equal(b, []byte(matcher.BodyJSONString))
 }
 
-func isMatchBodyJSON(req *http.Request, matcher Matcher) (bool, error) {
+func matchBodyJSON(req *http.Request, matcher Matcher) (bool, error) {
 	if matcher.BodyJSON == nil {
 		return true, nil
 	}

--- a/flute/matcher.go
+++ b/flute/matcher.go
@@ -18,20 +18,20 @@ func isMatchService(req *http.Request, service Service) bool {
 
 type matchFunc func(req *http.Request, matcher Matcher) (bool, error)
 
-var matchFuncs = [...]matchFunc{} //nolint:gochecknoglobals
+func matchPath(req *http.Request, matcher Matcher) (bool, error) {
+	return matcher.Path == "" || matcher.Path == req.URL.Path, nil
+}
+
+var matchFuncs = [...]matchFunc{ //nolint:gochecknoglobals
+	matchPath,
+}
 
 // isMatch returns whether the request matches with the matcher.
 // If the matcher has multiple conditions, IsMatch returns true if the request meets all conditions.
 func isMatch(req *http.Request, matcher Matcher) (bool, error) { //nolint:gocognit
 	for _, match := range matchFuncs {
-		f, err := match(req, matcher)
-		if err != nil || !f {
+		if f, err := match(req, matcher); err != nil || !f {
 			return f, err
-		}
-	}
-	if matcher.Path != "" {
-		if matcher.Path != req.URL.Path {
-			return false, nil
 		}
 	}
 	if matcher.Method != "" {

--- a/flute/matcher.go
+++ b/flute/matcher.go
@@ -27,20 +27,14 @@ func matchMethod(req *http.Request, matcher Matcher) (bool, error) {
 }
 
 var matchFuncs = [...]matchFunc{ //nolint:gochecknoglobals
-	matchPath, matchMethod, isMatchBodyString,
+	matchPath, matchMethod, isMatchBodyString, isMatchBodyJSON,
 }
 
 // isMatch returns whether the request matches with the matcher.
 // If the matcher has multiple conditions, IsMatch returns true if the request meets all conditions.
-func isMatch(req *http.Request, matcher Matcher) (bool, error) { //nolint:gocognit
+func isMatch(req *http.Request, matcher Matcher) (bool, error) {
 	for _, match := range matchFuncs {
 		if f, err := match(req, matcher); err != nil || !f {
-			return f, err
-		}
-	}
-	if matcher.BodyJSON != nil {
-		f, err := isMatchBodyJSON(req, matcher)
-		if err != nil || !f {
 			return f, err
 		}
 	}
@@ -136,6 +130,9 @@ func isMatchBodyJSONString(req *http.Request, matcher Matcher) (bool, error) {
 }
 
 func isMatchBodyJSON(req *http.Request, matcher Matcher) (bool, error) {
+	if matcher.BodyJSON == nil {
+		return true, nil
+	}
 	if req.Body == nil {
 		return false, nil
 	}

--- a/flute/matcher_internal_test.go
+++ b/flute/matcher_internal_test.go
@@ -324,12 +324,13 @@ func Benchmark_isMatch(b *testing.B) { //nolint:funlen
 	}
 }
 
-func Test_isMatchPartOfQuery(t *testing.T) {
+func Test_isMatchPartOfQuery(t *testing.T) { //nolint:funlen
 	data := []struct {
 		title   string
 		req     *http.Request
 		matcher Matcher
 		exp     bool
+		isErr   bool
 	}{
 		{
 			title: "query value doesn't match",
@@ -374,7 +375,12 @@ func Test_isMatchPartOfQuery(t *testing.T) {
 	for _, d := range data {
 		d := d
 		t.Run(d.title, func(t *testing.T) {
-			b := isMatchPartOfQuery(d.req, d.matcher)
+			b, err := isMatchPartOfQuery(d.req, d.matcher)
+			if d.isErr {
+				require.NotNil(t, err)
+				return
+			}
+			require.Nil(t, err)
 			if d.exp {
 				require.True(t, b)
 				return
@@ -435,7 +441,7 @@ func Benchmark_isMatchPartOfQuery(b *testing.B) {
 		d := d
 		b.Run(d.title, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				isMatchPartOfQuery(d.req, d.matcher)
+				_, _ = isMatchPartOfQuery(d.req, d.matcher)
 			}
 		})
 	}

--- a/flute/matcher_internal_test.go
+++ b/flute/matcher_internal_test.go
@@ -441,12 +441,13 @@ func Benchmark_isMatchPartOfQuery(b *testing.B) {
 	}
 }
 
-func Test_isMatchPartOfHeader(t *testing.T) {
+func Test_isMatchPartOfHeader(t *testing.T) { //nolint:funlen
 	data := []struct {
 		title   string
 		req     *http.Request
 		matcher Matcher
 		exp     bool
+		isErr   bool
 	}{
 		{
 			title: "header value doesn't match",
@@ -491,7 +492,12 @@ func Test_isMatchPartOfHeader(t *testing.T) {
 	for _, d := range data {
 		d := d
 		t.Run(d.title, func(t *testing.T) {
-			b := isMatchPartOfHeader(d.req, d.matcher)
+			b, err := isMatchPartOfHeader(d.req, d.matcher)
+			if d.isErr {
+				require.NotNil(t, err)
+				return
+			}
+			require.Nil(t, err)
 			if d.exp {
 				require.True(t, b)
 				return
@@ -552,7 +558,7 @@ func Benchmark_isMatchPartOfHeader(b *testing.B) {
 		d := d
 		b.Run(d.title, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				isMatchPartOfHeader(d.req, d.matcher)
+				_, _ = isMatchPartOfHeader(d.req, d.matcher)
 			}
 		})
 	}

--- a/flute/matcher_internal_test.go
+++ b/flute/matcher_internal_test.go
@@ -754,6 +754,9 @@ func Test_isMatchBodyJSON(t *testing.T) {
 		{
 			title: "request body is nil",
 			req:   &http.Request{},
+			matcher: Matcher{
+				BodyJSON: map[string]interface{}{"name": "foo"},
+			},
 		},
 		{
 			title: "request body json matches",

--- a/flute/matcher_internal_test.go
+++ b/flute/matcher_internal_test.go
@@ -558,7 +558,7 @@ func Benchmark_isMatchPartOfHeader(b *testing.B) {
 	}
 }
 
-func Test_isMatchBodyString(t *testing.T) { //nolint:dupl
+func Test_isMatchBodyString(t *testing.T) {
 	data := []struct {
 		title   string
 		req     *http.Request
@@ -568,7 +568,10 @@ func Test_isMatchBodyString(t *testing.T) { //nolint:dupl
 	}{
 		{
 			title: "request body is nil",
-			req:   &http.Request{},
+			matcher: Matcher{
+				BodyString: "foo",
+			},
+			req: &http.Request{},
 		},
 		{
 			title: "request body matches",
@@ -649,7 +652,7 @@ func Benchmark_isMatchBodyString(b *testing.B) {
 	}
 }
 
-func Test_isMatchBodyJSONString(t *testing.T) { //nolint:dupl
+func Test_isMatchBodyJSONString(t *testing.T) {
 	data := []struct {
 		title   string
 		req     *http.Request

--- a/flute/matcher_internal_test.go
+++ b/flute/matcher_internal_test.go
@@ -663,6 +663,9 @@ func Test_isMatchBodyJSONString(t *testing.T) {
 		{
 			title: "request body is nil",
 			req:   &http.Request{},
+			matcher: Matcher{
+				BodyJSONString: `{"name": "foo", "id": 10}`,
+			},
 		},
 		{
 			title: "request body json matches",

--- a/flute/matcher_internal_test.go
+++ b/flute/matcher_internal_test.go
@@ -70,15 +70,6 @@ func Test_isMatch(t *testing.T) { //nolint:funlen
 		exp     bool
 	}{
 		{
-			title: "if mathcer is nil, the request matches the matcher",
-			req: &http.Request{
-				URL: &url.URL{
-					Path: "/foo",
-				},
-			},
-			exp: true,
-		},
-		{
 			title: "path doesn't match",
 			req: &http.Request{
 				URL: &url.URL{
@@ -212,14 +203,6 @@ func Benchmark_isMatch(b *testing.B) { //nolint:funlen
 		req     *http.Request
 		matcher Matcher
 	}{
-		{
-			title: "if mathcer is nil, the request matches the matcher",
-			req: &http.Request{
-				URL: &url.URL{
-					Path: "/foo",
-				},
-			},
-		},
 		{
 			title: "path doesn't match",
 			req: &http.Request{

--- a/flute/matcher_internal_test.go
+++ b/flute/matcher_internal_test.go
@@ -324,7 +324,7 @@ func Benchmark_isMatch(b *testing.B) { //nolint:funlen
 	}
 }
 
-func Test_isMatchPartOfQuery(t *testing.T) { //nolint:funlen
+func Test_matchPartOfQuery(t *testing.T) { //nolint:funlen
 	data := []struct {
 		title   string
 		req     *http.Request
@@ -375,7 +375,7 @@ func Test_isMatchPartOfQuery(t *testing.T) { //nolint:funlen
 	for _, d := range data {
 		d := d
 		t.Run(d.title, func(t *testing.T) {
-			b, err := isMatchPartOfQuery(d.req, d.matcher)
+			b, err := matchPartOfQuery(d.req, d.matcher)
 			if d.isErr {
 				require.NotNil(t, err)
 				return
@@ -390,7 +390,7 @@ func Test_isMatchPartOfQuery(t *testing.T) { //nolint:funlen
 	}
 }
 
-func Benchmark_isMatchPartOfQuery(b *testing.B) {
+func Benchmark_matchPartOfQuery(b *testing.B) {
 	data := []struct {
 		title   string
 		req     *http.Request
@@ -441,13 +441,13 @@ func Benchmark_isMatchPartOfQuery(b *testing.B) {
 		d := d
 		b.Run(d.title, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, _ = isMatchPartOfQuery(d.req, d.matcher)
+				_, _ = matchPartOfQuery(d.req, d.matcher)
 			}
 		})
 	}
 }
 
-func Test_isMatchPartOfHeader(t *testing.T) { //nolint:funlen
+func Test_matchPartOfHeader(t *testing.T) { //nolint:funlen
 	data := []struct {
 		title   string
 		req     *http.Request
@@ -498,7 +498,7 @@ func Test_isMatchPartOfHeader(t *testing.T) { //nolint:funlen
 	for _, d := range data {
 		d := d
 		t.Run(d.title, func(t *testing.T) {
-			b, err := isMatchPartOfHeader(d.req, d.matcher)
+			b, err := matchPartOfHeader(d.req, d.matcher)
 			if d.isErr {
 				require.NotNil(t, err)
 				return
@@ -513,7 +513,7 @@ func Test_isMatchPartOfHeader(t *testing.T) { //nolint:funlen
 	}
 }
 
-func Benchmark_isMatchPartOfHeader(b *testing.B) {
+func Benchmark_matchPartOfHeader(b *testing.B) {
 	data := []struct {
 		title   string
 		req     *http.Request
@@ -564,13 +564,13 @@ func Benchmark_isMatchPartOfHeader(b *testing.B) {
 		d := d
 		b.Run(d.title, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, _ = isMatchPartOfHeader(d.req, d.matcher)
+				_, _ = matchPartOfHeader(d.req, d.matcher)
 			}
 		})
 	}
 }
 
-func Test_isMatchBodyString(t *testing.T) {
+func Test_matchBodyString(t *testing.T) {
 	data := []struct {
 		title   string
 		req     *http.Request
@@ -609,7 +609,7 @@ func Test_isMatchBodyString(t *testing.T) {
 	for _, d := range data {
 		d := d
 		t.Run(d.title, func(t *testing.T) {
-			b, err := isMatchBodyString(d.req, d.matcher)
+			b, err := matchBodyString(d.req, d.matcher)
 			if d.isErr {
 				require.NotNil(t, err)
 				return
@@ -624,7 +624,7 @@ func Test_isMatchBodyString(t *testing.T) {
 	}
 }
 
-func Benchmark_isMatchBodyString(b *testing.B) {
+func Benchmark_matchBodyString(b *testing.B) {
 	data := []struct {
 		title   string
 		req     *http.Request
@@ -658,13 +658,13 @@ func Benchmark_isMatchBodyString(b *testing.B) {
 		d := d
 		b.Run(d.title, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, _ = isMatchBodyString(d.req, d.matcher)
+				_, _ = matchBodyString(d.req, d.matcher)
 			}
 		})
 	}
 }
 
-func Test_isMatchBodyJSONString(t *testing.T) {
+func Test_matchBodyJSONString(t *testing.T) {
 	data := []struct {
 		title   string
 		req     *http.Request
@@ -703,7 +703,7 @@ func Test_isMatchBodyJSONString(t *testing.T) {
 	for _, d := range data {
 		d := d
 		t.Run(d.title, func(t *testing.T) {
-			b, err := isMatchBodyJSONString(d.req, d.matcher)
+			b, err := matchBodyJSONString(d.req, d.matcher)
 			if d.isErr {
 				require.NotNil(t, err)
 				return
@@ -718,7 +718,7 @@ func Test_isMatchBodyJSONString(t *testing.T) {
 	}
 }
 
-func Benchmark_isMatchBodyJSONString(b *testing.B) {
+func Benchmark_matchBodyJSONString(b *testing.B) {
 	data := []struct {
 		title   string
 		req     *http.Request
@@ -752,13 +752,13 @@ func Benchmark_isMatchBodyJSONString(b *testing.B) {
 		d := d
 		b.Run(d.title, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, _ = isMatchBodyJSONString(d.req, d.matcher)
+				_, _ = matchBodyJSONString(d.req, d.matcher)
 			}
 		})
 	}
 }
 
-func Test_isMatchBodyJSON(t *testing.T) {
+func Test_matchBodyJSON(t *testing.T) {
 	data := []struct {
 		title   string
 		req     *http.Request
@@ -797,7 +797,7 @@ func Test_isMatchBodyJSON(t *testing.T) {
 	for _, d := range data {
 		d := d
 		t.Run(d.title, func(t *testing.T) {
-			b, err := isMatchBodyJSON(d.req, d.matcher)
+			b, err := matchBodyJSON(d.req, d.matcher)
 			if d.isErr {
 				require.NotNil(t, err)
 				return
@@ -812,7 +812,7 @@ func Test_isMatchBodyJSON(t *testing.T) {
 	}
 }
 
-func Benchmark_isMatchBodyJSON(b *testing.B) {
+func Benchmark_matchBodyJSON(b *testing.B) {
 	data := []struct {
 		title   string
 		req     *http.Request
@@ -846,7 +846,7 @@ func Benchmark_isMatchBodyJSON(b *testing.B) {
 		d := d
 		b.Run(d.title, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, _ = isMatchBodyJSON(d.req, d.matcher)
+				_, _ = matchBodyJSON(d.req, d.matcher)
 			}
 		})
 	}

--- a/flute/matcher_internal_test.go
+++ b/flute/matcher_internal_test.go
@@ -35,7 +35,7 @@ func Test_isMatchService(t *testing.T) {
 					Scheme: d.scheme,
 					Host:   d.host,
 				},
-			}, &Service{
+			}, Service{
 				Endpoint: d.endpoint,
 			})
 			if d.exp {
@@ -55,7 +55,7 @@ func Benchmark_isMatchService(b *testing.B) {
 				Scheme: "http",
 				Host:   "example.com",
 			},
-		}, &Service{
+		}, Service{
 			Endpoint: "http://example.com",
 		})
 	}
@@ -65,7 +65,7 @@ func Test_isMatch(t *testing.T) { //nolint:funlen
 	data := []struct {
 		title   string
 		req     *http.Request
-		matcher *Matcher
+		matcher Matcher
 		isErr   bool
 		exp     bool
 	}{
@@ -85,7 +85,7 @@ func Test_isMatch(t *testing.T) { //nolint:funlen
 					Path: "/foo",
 				},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				Path: "/bar",
 			},
 		},
@@ -94,7 +94,7 @@ func Test_isMatch(t *testing.T) { //nolint:funlen
 			req: &http.Request{
 				Method: "GET",
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				Method: "POST",
 			},
 		},
@@ -103,7 +103,7 @@ func Test_isMatch(t *testing.T) { //nolint:funlen
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader("foo")),
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				BodyString: "hello",
 			},
 		},
@@ -112,7 +112,7 @@ func Test_isMatch(t *testing.T) { //nolint:funlen
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader(`"foo"`)),
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				BodyJSON: 10,
 			},
 		},
@@ -121,7 +121,7 @@ func Test_isMatch(t *testing.T) { //nolint:funlen
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader(`"foo"`)),
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				BodyJSONString: `"bar"`,
 			},
 		},
@@ -132,7 +132,7 @@ func Test_isMatch(t *testing.T) { //nolint:funlen
 					"FOO": []string{"foo"},
 				},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				PartOfHeader: http.Header{
 					"FOO": []string{"bar"},
 				},
@@ -146,7 +146,7 @@ func Test_isMatch(t *testing.T) { //nolint:funlen
 					"BAR": []string{"bar"},
 				},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				Header: http.Header{
 					"FOO": []string{"foo"},
 				},
@@ -159,7 +159,7 @@ func Test_isMatch(t *testing.T) { //nolint:funlen
 					RawQuery: "name=foo",
 				},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				PartOfQuery: url.Values{
 					"name": []string{"bar"},
 				},
@@ -172,7 +172,7 @@ func Test_isMatch(t *testing.T) { //nolint:funlen
 					RawQuery: "name=foo&age=10",
 				},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				Query: url.Values{
 					"name": []string{"foo"},
 				},
@@ -180,7 +180,7 @@ func Test_isMatch(t *testing.T) { //nolint:funlen
 		},
 		{
 			title: "match function doesn't match",
-			matcher: &Matcher{
+			matcher: Matcher{
 				Match: func(req *http.Request) (bool, error) {
 					return false, nil
 				},
@@ -210,7 +210,7 @@ func Benchmark_isMatch(b *testing.B) { //nolint:funlen
 	data := []struct {
 		title   string
 		req     *http.Request
-		matcher *Matcher
+		matcher Matcher
 	}{
 		{
 			title: "if mathcer is nil, the request matches the matcher",
@@ -227,7 +227,7 @@ func Benchmark_isMatch(b *testing.B) { //nolint:funlen
 					Path: "/foo",
 				},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				Path: "/bar",
 			},
 		},
@@ -236,7 +236,7 @@ func Benchmark_isMatch(b *testing.B) { //nolint:funlen
 			req: &http.Request{
 				Method: "GET",
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				Method: "POST",
 			},
 		},
@@ -245,7 +245,7 @@ func Benchmark_isMatch(b *testing.B) { //nolint:funlen
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader("foo")),
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				BodyString: "hello",
 			},
 		},
@@ -254,7 +254,7 @@ func Benchmark_isMatch(b *testing.B) { //nolint:funlen
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader(`"foo"`)),
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				BodyJSON: 10,
 			},
 		},
@@ -263,7 +263,7 @@ func Benchmark_isMatch(b *testing.B) { //nolint:funlen
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader(`"foo"`)),
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				BodyJSONString: `"bar"`,
 			},
 		},
@@ -274,7 +274,7 @@ func Benchmark_isMatch(b *testing.B) { //nolint:funlen
 					"FOO": []string{"foo"},
 				},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				PartOfHeader: http.Header{
 					"FOO": []string{"bar"},
 				},
@@ -288,7 +288,7 @@ func Benchmark_isMatch(b *testing.B) { //nolint:funlen
 					"BAR": []string{"bar"},
 				},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				Header: http.Header{
 					"FOO": []string{"foo"},
 				},
@@ -301,7 +301,7 @@ func Benchmark_isMatch(b *testing.B) { //nolint:funlen
 					RawQuery: "name=foo",
 				},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				PartOfQuery: url.Values{
 					"name": []string{"bar"},
 				},
@@ -314,7 +314,7 @@ func Benchmark_isMatch(b *testing.B) { //nolint:funlen
 					RawQuery: "name=foo&age=10",
 				},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				Query: url.Values{
 					"name": []string{"foo"},
 				},
@@ -322,7 +322,7 @@ func Benchmark_isMatch(b *testing.B) { //nolint:funlen
 		},
 		{
 			title: "match function doesn't match",
-			matcher: &Matcher{
+			matcher: Matcher{
 				Match: func(req *http.Request) (bool, error) {
 					return false, nil
 				},
@@ -345,7 +345,7 @@ func Test_isMatchPartOfQuery(t *testing.T) {
 	data := []struct {
 		title   string
 		req     *http.Request
-		matcher *Matcher
+		matcher Matcher
 		exp     bool
 	}{
 		{
@@ -355,7 +355,7 @@ func Test_isMatchPartOfQuery(t *testing.T) {
 					RawQuery: "name=foo",
 				},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				PartOfQuery: url.Values{
 					"name": []string{"bar"},
 				},
@@ -366,7 +366,7 @@ func Test_isMatchPartOfQuery(t *testing.T) {
 			req: &http.Request{
 				URL: &url.URL{},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				PartOfQuery: url.Values{
 					"name": nil,
 				},
@@ -379,7 +379,7 @@ func Test_isMatchPartOfQuery(t *testing.T) {
 					RawQuery: "name=foo",
 				},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				PartOfQuery: url.Values{
 					"name": []string{"foo"},
 				},
@@ -405,7 +405,7 @@ func Benchmark_isMatchPartOfQuery(b *testing.B) {
 	data := []struct {
 		title   string
 		req     *http.Request
-		matcher *Matcher
+		matcher Matcher
 		exp     bool
 	}{
 		{
@@ -415,7 +415,7 @@ func Benchmark_isMatchPartOfQuery(b *testing.B) {
 					RawQuery: "name=foo",
 				},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				PartOfQuery: url.Values{
 					"name": []string{"bar"},
 				},
@@ -426,7 +426,7 @@ func Benchmark_isMatchPartOfQuery(b *testing.B) {
 			req: &http.Request{
 				URL: &url.URL{},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				PartOfQuery: url.Values{
 					"name": nil,
 				},
@@ -439,7 +439,7 @@ func Benchmark_isMatchPartOfQuery(b *testing.B) {
 					RawQuery: "name=foo",
 				},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				PartOfQuery: url.Values{
 					"name": []string{"foo"},
 				},
@@ -462,7 +462,7 @@ func Test_isMatchPartOfHeader(t *testing.T) {
 	data := []struct {
 		title   string
 		req     *http.Request
-		matcher *Matcher
+		matcher Matcher
 		exp     bool
 	}{
 		{
@@ -472,7 +472,7 @@ func Test_isMatchPartOfHeader(t *testing.T) {
 					"FOO": []string{"foo"},
 				},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				PartOfHeader: http.Header{
 					"FOO": []string{"bar"},
 				},
@@ -483,7 +483,7 @@ func Test_isMatchPartOfHeader(t *testing.T) {
 			req: &http.Request{
 				Header: http.Header{},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				PartOfHeader: http.Header{
 					"FOO": nil,
 				},
@@ -496,7 +496,7 @@ func Test_isMatchPartOfHeader(t *testing.T) {
 					"FOO": []string{"foo"},
 				},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				PartOfHeader: http.Header{
 					"FOO": []string{"foo"},
 				},
@@ -522,7 +522,7 @@ func Benchmark_isMatchPartOfHeader(b *testing.B) {
 	data := []struct {
 		title   string
 		req     *http.Request
-		matcher *Matcher
+		matcher Matcher
 		exp     bool
 	}{
 		{
@@ -532,7 +532,7 @@ func Benchmark_isMatchPartOfHeader(b *testing.B) {
 					"FOO": []string{"foo"},
 				},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				PartOfHeader: http.Header{
 					"FOO": []string{"bar"},
 				},
@@ -543,7 +543,7 @@ func Benchmark_isMatchPartOfHeader(b *testing.B) {
 			req: &http.Request{
 				Header: http.Header{},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				PartOfHeader: http.Header{
 					"FOO": nil,
 				},
@@ -556,7 +556,7 @@ func Benchmark_isMatchPartOfHeader(b *testing.B) {
 					"FOO": []string{"foo"},
 				},
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				PartOfHeader: http.Header{
 					"FOO": []string{"foo"},
 				},
@@ -579,7 +579,7 @@ func Test_isMatchBodyString(t *testing.T) { //nolint:dupl
 	data := []struct {
 		title   string
 		req     *http.Request
-		matcher *Matcher
+		matcher Matcher
 		isErr   bool
 		exp     bool
 	}{
@@ -592,7 +592,7 @@ func Test_isMatchBodyString(t *testing.T) { //nolint:dupl
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader("foo")),
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				BodyString: "foo",
 			},
 			exp: true,
@@ -602,7 +602,7 @@ func Test_isMatchBodyString(t *testing.T) { //nolint:dupl
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader("foo")),
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				BodyString: "bar",
 			},
 		},
@@ -630,7 +630,7 @@ func Benchmark_isMatchBodyString(b *testing.B) {
 	data := []struct {
 		title   string
 		req     *http.Request
-		matcher *Matcher
+		matcher Matcher
 	}{
 		{
 			title: "request body is nil",
@@ -641,7 +641,7 @@ func Benchmark_isMatchBodyString(b *testing.B) {
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader("foo")),
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				BodyString: "foo",
 			},
 		},
@@ -650,7 +650,7 @@ func Benchmark_isMatchBodyString(b *testing.B) {
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader("foo")),
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				BodyString: "bar",
 			},
 		},
@@ -670,7 +670,7 @@ func Test_isMatchBodyJSONString(t *testing.T) { //nolint:dupl
 	data := []struct {
 		title   string
 		req     *http.Request
-		matcher *Matcher
+		matcher Matcher
 		isErr   bool
 		exp     bool
 	}{
@@ -683,7 +683,7 @@ func Test_isMatchBodyJSONString(t *testing.T) { //nolint:dupl
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader(`{"id": 10, "name": "foo"}`)),
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				BodyJSONString: `{"name": "foo", "id": 10}`,
 			},
 			exp: true,
@@ -693,7 +693,7 @@ func Test_isMatchBodyJSONString(t *testing.T) { //nolint:dupl
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader(`{"id": 10, "name": "foo"}`)),
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				BodyJSONString: `{"name": "foo", "id": 9}`,
 			},
 		},
@@ -721,7 +721,7 @@ func Benchmark_isMatchBodyJSONString(b *testing.B) {
 	data := []struct {
 		title   string
 		req     *http.Request
-		matcher *Matcher
+		matcher Matcher
 	}{
 		{
 			title: "request body is nil",
@@ -732,7 +732,7 @@ func Benchmark_isMatchBodyJSONString(b *testing.B) {
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader(`{"id": 10, "name": "foo"}`)),
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				BodyJSONString: `{"name": "foo", "id": 10}`,
 			},
 		},
@@ -741,7 +741,7 @@ func Benchmark_isMatchBodyJSONString(b *testing.B) {
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader(`{"id": 10, "name": "foo"}`)),
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				BodyJSONString: `{"name": "foo", "id": 9}`,
 			},
 		},
@@ -761,7 +761,7 @@ func Test_isMatchBodyJSON(t *testing.T) {
 	data := []struct {
 		title   string
 		req     *http.Request
-		matcher *Matcher
+		matcher Matcher
 		isErr   bool
 		exp     bool
 	}{
@@ -774,7 +774,7 @@ func Test_isMatchBodyJSON(t *testing.T) {
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader(`{"name": "foo"}`)),
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				BodyJSON: map[string]interface{}{"name": "foo"},
 			},
 			exp: true,
@@ -784,7 +784,7 @@ func Test_isMatchBodyJSON(t *testing.T) {
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader(`{"id": 10, "name": "foo"}`)),
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				BodyJSON: map[string]interface{}{"name": "foo"},
 			},
 		},
@@ -812,7 +812,7 @@ func Benchmark_isMatchBodyJSON(b *testing.B) {
 	data := []struct {
 		title   string
 		req     *http.Request
-		matcher *Matcher
+		matcher Matcher
 	}{
 		{
 			title: "request body is nil",
@@ -823,7 +823,7 @@ func Benchmark_isMatchBodyJSON(b *testing.B) {
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader(`{"name": "foo"}`)),
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				BodyJSON: map[string]interface{}{"name": "foo"},
 			},
 		},
@@ -832,7 +832,7 @@ func Benchmark_isMatchBodyJSON(b *testing.B) {
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader(`{"id": 10, "name": "foo"}`)),
 			},
-			matcher: &Matcher{
+			matcher: Matcher{
 				BodyJSON: map[string]interface{}{"name": "foo"},
 			},
 		},

--- a/flute/response.go
+++ b/flute/response.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-func createHTTPResponse(req *http.Request, resp *Response) (*http.Response, error) {
+func createHTTPResponse(req *http.Request, resp Response) (*http.Response, error) {
 	if resp.Response != nil {
 		return resp.Response(req)
 	}

--- a/flute/response_internal_test.go
+++ b/flute/response_internal_test.go
@@ -23,7 +23,7 @@ func Test_createHTTPResponse(t *testing.T) { //nolint:funlen
 	data := []struct {
 		title string
 		req   *http.Request
-		resp  *Response
+		resp  Response
 		isErr bool
 		exp   *http.Response
 		body  string
@@ -31,7 +31,7 @@ func Test_createHTTPResponse(t *testing.T) { //nolint:funlen
 		{
 			title: "body json isn't nil",
 			req:   &http.Request{},
-			resp: &Response{
+			resp: Response{
 				Base: http.Response{
 					Header: http.Header{
 						"FOO": []string{"foo"},
@@ -49,7 +49,7 @@ func Test_createHTTPResponse(t *testing.T) { //nolint:funlen
 		{
 			title: "failed to marshal json",
 			req:   &http.Request{},
-			resp: &Response{
+			resp: Response{
 				BodyJSON: &invalidMarshaler{},
 			},
 			isErr: true,
@@ -57,7 +57,7 @@ func Test_createHTTPResponse(t *testing.T) { //nolint:funlen
 		{
 			title: "body string isn't nil",
 			req:   &http.Request{},
-			resp: &Response{
+			resp: Response{
 				BodyString: `{"foo":"bar"}`,
 			},
 			exp: &http.Response{
@@ -68,7 +68,7 @@ func Test_createHTTPResponse(t *testing.T) { //nolint:funlen
 		{
 			title: "nil request body",
 			req:   &http.Request{},
-			resp:  &Response{},
+			resp:  Response{},
 			exp: &http.Response{
 				Body: ioutil.NopCloser(strings.NewReader("")),
 			},
@@ -76,7 +76,7 @@ func Test_createHTTPResponse(t *testing.T) { //nolint:funlen
 		{
 			title: "resp.Response",
 			req:   &http.Request{},
-			resp: &Response{
+			resp: Response{
 				Response: func(req *http.Request) (*http.Response, error) {
 					return &http.Response{
 						Body:       ioutil.NopCloser(strings.NewReader("foo")),
@@ -126,14 +126,14 @@ func Benchmark_createHTTPResponse(b *testing.B) { //nolint:funlen
 	data := []struct {
 		title string
 		req   *http.Request
-		resp  *Response
+		resp  Response
 		isErr bool
 		body  string
 	}{
 		{
 			title: "body json isn't nil",
 			req:   &http.Request{},
-			resp: &Response{
+			resp: Response{
 				Base: http.Response{
 					Header: http.Header{
 						"FOO": []string{"foo"},
@@ -148,7 +148,7 @@ func Benchmark_createHTTPResponse(b *testing.B) { //nolint:funlen
 		{
 			title: "failed to marshal json",
 			req:   &http.Request{},
-			resp: &Response{
+			resp: Response{
 				BodyJSON: &invalidMarshaler{},
 			},
 			isErr: true,
@@ -156,7 +156,7 @@ func Benchmark_createHTTPResponse(b *testing.B) { //nolint:funlen
 		{
 			title: "body string isn't nil",
 			req:   &http.Request{},
-			resp: &Response{
+			resp: Response{
 				BodyString: `{"foo":"bar"}`,
 			},
 			body: `{"foo":"bar"}`,
@@ -164,12 +164,12 @@ func Benchmark_createHTTPResponse(b *testing.B) { //nolint:funlen
 		{
 			title: "nil request body",
 			req:   &http.Request{},
-			resp:  &Response{},
+			resp:  Response{},
 		},
 		{
 			title: "resp.Response",
 			req:   &http.Request{},
-			resp: &Response{
+			resp: Response{
 				Response: func(req *http.Request) (*http.Response, error) {
 					return &http.Response{
 						Body:       ioutil.NopCloser(strings.NewReader("foo")),

--- a/flute/struct.go
+++ b/flute/struct.go
@@ -30,10 +30,9 @@ type (
 	// Route is the pair of the macher, tester, and response.
 	Route struct {
 		// Name is embedded the assertion and useful to specify where the test fails.
-		Name    string
-		Matcher Matcher
-		// SPEC if the tester is nil, no test is run
-		Tester   *Tester
+		Name     string
+		Matcher  Matcher
+		Tester   Tester
 		Response Response
 	}
 

--- a/flute/struct.go
+++ b/flute/struct.go
@@ -30,12 +30,11 @@ type (
 	// Route is the pair of the macher, tester, and response.
 	Route struct {
 		// Name is embedded the assertion and useful to specify where the test fails.
-		Name string
-		// SPEC if the matcher is nil, the route matches the request.
-		Matcher *Matcher
+		Name    string
+		Matcher Matcher
 		// SPEC if the tester is nil, no test is run
 		Tester   *Tester
-		Response *Response
+		Response Response
 	}
 
 	// Matcher has conditions the request matches with the route.
@@ -66,7 +65,7 @@ type (
 
 	// Tester has the request's tests.
 	Tester struct {
-		Test func(*testing.T, *http.Request, *Service, *Route)
+		Test func(*testing.T, *http.Request, Service, Route)
 		// Path is the request path.
 		Path string
 		// Path is the request method such as "GET".

--- a/flute/tester.go
+++ b/flute/tester.go
@@ -13,10 +13,6 @@ import (
 
 func testRequest(t *testing.T, req *http.Request, service Service, route Route) {
 	tester := route.Tester
-	if tester == nil {
-		// SPEC if the tester is nil, do nothing.
-		return
-	}
 	if tester.Path != "" {
 		testPath(t, req, service, route)
 	}

--- a/flute/tester.go
+++ b/flute/tester.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func testRequest(t *testing.T, req *http.Request, service *Service, route *Route) {
+func testRequest(t *testing.T, req *http.Request, service Service, route Route) {
 	tester := route.Tester
 	if tester == nil {
 		// SPEC if the tester is nil, do nothing.
@@ -59,9 +59,7 @@ service: %s
 request name: %s`, msg, srv, reqName)
 }
 
-func testBodyString(
-	t *testing.T, req *http.Request, service *Service, route *Route,
-) {
+func testBodyString(t *testing.T, req *http.Request, service Service, route Route) {
 	reqName := route.Name
 	srv := service.Endpoint
 	tester := route.Tester
@@ -85,7 +83,7 @@ func testBodyString(
 		makeMsg("request body should match", srv, reqName))
 }
 
-func testPath(t *testing.T, req *http.Request, service *Service, route *Route) {
+func testPath(t *testing.T, req *http.Request, service Service, route Route) {
 	reqName := route.Name
 	srv := service.Endpoint
 	tester := route.Tester
@@ -95,7 +93,7 @@ func testPath(t *testing.T, req *http.Request, service *Service, route *Route) {
 		makeMsg("request path should match", srv, reqName))
 }
 
-func testMethod(t *testing.T, req *http.Request, service *Service, route *Route) {
+func testMethod(t *testing.T, req *http.Request, service Service, route Route) {
 	reqName := route.Name
 	srv := service.Endpoint
 	tester := route.Tester
@@ -105,7 +103,7 @@ func testMethod(t *testing.T, req *http.Request, service *Service, route *Route)
 		makeMsg("request method should match", srv, reqName))
 }
 
-func testBodyJSON(t *testing.T, req *http.Request, service *Service, route *Route) {
+func testBodyJSON(t *testing.T, req *http.Request, service Service, route Route) {
 	reqName := route.Name
 	srv := service.Endpoint
 	tester := route.Tester
@@ -137,7 +135,7 @@ func testBodyJSON(t *testing.T, req *http.Request, service *Service, route *Rout
 }
 
 func testBodyJSONString(
-	t *testing.T, req *http.Request, service *Service, route *Route,
+	t *testing.T, req *http.Request, service Service, route Route,
 ) {
 	reqName := route.Name
 	srv := service.Endpoint
@@ -162,7 +160,7 @@ func testBodyJSONString(
 		makeMsg("request body should match", srv, reqName))
 }
 
-func testPartOfHeader(t *testing.T, req *http.Request, service *Service, route *Route) {
+func testPartOfHeader(t *testing.T, req *http.Request, service Service, route Route) {
 	reqName := route.Name
 	srv := service.Endpoint
 
@@ -182,7 +180,7 @@ func testPartOfHeader(t *testing.T, req *http.Request, service *Service, route *
 	}
 }
 
-func testPartOfQuery(t *testing.T, req *http.Request, service *Service, route *Route) {
+func testPartOfQuery(t *testing.T, req *http.Request, service Service, route Route) {
 	reqName := route.Name
 	srv := service.Endpoint
 

--- a/flute/tester.go
+++ b/flute/tester.go
@@ -16,6 +16,7 @@ type testFunc func(t *testing.T, req *http.Request, service Service, route Route
 var testFuncs = [...]testFunc{ //nolint:gochecknoglobals
 	testPath, testMethod, testBodyString, testBodyJSON,
 	testBodyJSONString, testPartOfHeader, testHeader, testPartOfQuery,
+	testQuery,
 }
 
 func testHeader(t *testing.T, req *http.Request, service Service, route Route) {
@@ -27,16 +28,20 @@ func testHeader(t *testing.T, req *http.Request, service Service, route Route) {
 		makeMsg("request header should match", service.Endpoint, route.Name))
 }
 
+func testQuery(t *testing.T, req *http.Request, service Service, route Route) {
+	if route.Tester.Query == nil {
+		return
+	}
+	assert.Equal(
+		t, route.Tester.Query, req.URL.Query(),
+		makeMsg("request query parameter should match", service.Endpoint, route.Name))
+}
+
 func testRequest(t *testing.T, req *http.Request, service Service, route Route) {
 	for _, fn := range testFuncs {
 		fn(t, req, service, route)
 	}
 	tester := route.Tester
-	if tester.Query != nil {
-		assert.Equal(
-			t, tester.Query, req.URL.Query(),
-			makeMsg("request query parameter should match", service.Endpoint, route.Name))
-	}
 	if tester.Test != nil {
 		tester.Test(t, req, service, route)
 	}

--- a/flute/tester.go
+++ b/flute/tester.go
@@ -11,11 +11,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type testFunc func(t *testing.T, req *http.Request, service Service, route Route)
+
+var testFuncs = [...]testFunc{ //nolint:gochecknoglobals
+	testPath,
+}
+
 func testRequest(t *testing.T, req *http.Request, service Service, route Route) {
-	tester := route.Tester
-	if tester.Path != "" {
-		testPath(t, req, service, route)
+	for _, fn := range testFuncs {
+		fn(t, req, service, route)
 	}
+	tester := route.Tester
 	if tester.Method != "" {
 		testMethod(t, req, service, route)
 	}
@@ -80,13 +86,12 @@ func testBodyString(t *testing.T, req *http.Request, service Service, route Rout
 }
 
 func testPath(t *testing.T, req *http.Request, service Service, route Route) {
-	reqName := route.Name
-	srv := service.Endpoint
-	tester := route.Tester
-
+	if route.Tester.Path == "" {
+		return
+	}
 	assert.Equal(
-		t, tester.Path, req.URL.Path,
-		makeMsg("request path should match", srv, reqName))
+		t, route.Tester.Path, req.URL.Path,
+		makeMsg("request path should match", service.Endpoint, route.Name))
 }
 
 func testMethod(t *testing.T, req *http.Request, service Service, route Route) {

--- a/flute/tester.go
+++ b/flute/tester.go
@@ -14,7 +14,7 @@ import (
 type testFunc func(t *testing.T, req *http.Request, service Service, route Route)
 
 var testFuncs = [...]testFunc{ //nolint:gochecknoglobals
-	testPath,
+	testPath, testMethod,
 }
 
 func testRequest(t *testing.T, req *http.Request, service Service, route Route) {
@@ -22,9 +22,6 @@ func testRequest(t *testing.T, req *http.Request, service Service, route Route) 
 		fn(t, req, service, route)
 	}
 	tester := route.Tester
-	if tester.Method != "" {
-		testMethod(t, req, service, route)
-	}
 	if tester.BodyString != "" {
 		testBodyString(t, req, service, route)
 	}
@@ -95,13 +92,13 @@ func testPath(t *testing.T, req *http.Request, service Service, route Route) {
 }
 
 func testMethod(t *testing.T, req *http.Request, service Service, route Route) {
-	reqName := route.Name
-	srv := service.Endpoint
-	tester := route.Tester
+	if route.Tester.Method == "" {
+		return
+	}
 
 	assert.Equal(
-		t, strings.ToUpper(tester.Method), strings.ToUpper(req.Method),
-		makeMsg("request method should match", srv, reqName))
+		t, strings.ToUpper(route.Tester.Method), strings.ToUpper(req.Method),
+		makeMsg("request method should match", service.Endpoint, route.Name))
 }
 
 func testBodyJSON(t *testing.T, req *http.Request, service Service, route Route) {

--- a/flute/tester_internal_test.go
+++ b/flute/tester_internal_test.go
@@ -51,7 +51,7 @@ func Test_testRequest(t *testing.T) { //nolint:funlen
 			},
 			service: Service{},
 			route: Route{
-				Tester: &Tester{
+				Tester: Tester{
 					Method: "POST",
 					Path:   "/users",
 					BodyJSONString: `{
@@ -83,7 +83,7 @@ func Test_testRequest(t *testing.T) { //nolint:funlen
 			},
 			service: Service{},
 			route: Route{
-				Tester: &Tester{
+				Tester: Tester{
 					BodyString: `foo`,
 				},
 			},
@@ -95,7 +95,7 @@ func Test_testRequest(t *testing.T) { //nolint:funlen
 			},
 			service: Service{},
 			route: Route{
-				Tester: &Tester{
+				Tester: Tester{
 					BodyJSON: []map[string]interface{}{
 						{
 							"name": "foo",
@@ -155,7 +155,7 @@ func Test_testBodyString(t *testing.T) {
 			},
 			service: Service{},
 			route: Route{
-				Tester: &Tester{
+				Tester: Tester{
 					BodyString: `"foo"`,
 				},
 			},
@@ -165,7 +165,7 @@ func Test_testBodyString(t *testing.T) {
 			req:     &http.Request{},
 			service: Service{},
 			route: Route{
-				Tester: &Tester{
+				Tester: Tester{
 					BodyString: "",
 				},
 			},
@@ -196,7 +196,7 @@ func Test_testPath(t *testing.T) {
 			},
 			service: Service{},
 			route: Route{
-				Tester: &Tester{
+				Tester: Tester{
 					Path: "/foo",
 				},
 			},
@@ -225,7 +225,7 @@ func Test_testMethod(t *testing.T) {
 			},
 			service: Service{},
 			route: Route{
-				Tester: &Tester{
+				Tester: Tester{
 					Method: "put",
 				},
 			},
@@ -254,7 +254,7 @@ func Test_testBodyJSON(t *testing.T) {
 			},
 			service: Service{},
 			route: Route{
-				Tester: &Tester{
+				Tester: Tester{
 					BodyJSON: []map[string]string{
 						{
 							"foo": "bar",
@@ -268,7 +268,7 @@ func Test_testBodyJSON(t *testing.T) {
 			req:     &http.Request{},
 			service: Service{},
 			route: Route{
-				Tester: &Tester{},
+				Tester: Tester{},
 			},
 		},
 	}
@@ -295,7 +295,7 @@ func Test_testBodyJSONString(t *testing.T) {
 			},
 			service: Service{},
 			route: Route{
-				Tester: &Tester{
+				Tester: Tester{
 					BodyJSONString: `[
 					{"foo":"bar"}
 					]`,
@@ -307,7 +307,7 @@ func Test_testBodyJSONString(t *testing.T) {
 			req:     &http.Request{},
 			service: Service{},
 			route: Route{
-				Tester: &Tester{},
+				Tester: Tester{},
 			},
 		},
 	}
@@ -337,7 +337,7 @@ func Test_testPartOfHeader(t *testing.T) {
 			},
 			service: Service{},
 			route: Route{
-				Tester: &Tester{
+				Tester: Tester{
 					Header: http.Header{
 						"FOO": []string{"foo"},
 						"BAR": nil,
@@ -371,7 +371,7 @@ func Test_testPartOfQuery(t *testing.T) {
 			},
 			service: Service{},
 			route: Route{
-				Tester: &Tester{
+				Tester: Tester{
 					Query: url.Values{
 						"name": []string{"foo"},
 					},

--- a/flute/tester_internal_test.go
+++ b/flute/tester_internal_test.go
@@ -14,8 +14,8 @@ func Test_testRequest(t *testing.T) { //nolint:funlen
 	data := []struct {
 		title   string
 		req     *http.Request
-		service *Service
-		route   *Route
+		service Service
+		route   Route
 	}{
 		{
 			title: "if the tester is nil, do nothing",
@@ -30,7 +30,7 @@ func Test_testRequest(t *testing.T) { //nolint:funlen
 				  "email": "foo@example.com"
 				}`)),
 			},
-			route: &Route{},
+			route: Route{},
 		},
 		{
 			title: "body json string",
@@ -49,8 +49,8 @@ func Test_testRequest(t *testing.T) { //nolint:funlen
 					"Content-Type":  []string{"application/json"},
 				},
 			},
-			service: &Service{},
-			route: &Route{
+			service: Service{},
+			route: Route{
 				Tester: &Tester{
 					Method: "POST",
 					Path:   "/users",
@@ -72,7 +72,7 @@ func Test_testRequest(t *testing.T) { //nolint:funlen
 						"name": []string{"foo"},
 						"age":  []string{"10"},
 					},
-					Test: func(t *testing.T, req *http.Request, service *Service, route *Route) {},
+					Test: func(t *testing.T, req *http.Request, service Service, route Route) {},
 				},
 			},
 		},
@@ -81,8 +81,8 @@ func Test_testRequest(t *testing.T) { //nolint:funlen
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader(`foo`)),
 			},
-			service: &Service{},
-			route: &Route{
+			service: Service{},
+			route: Route{
 				Tester: &Tester{
 					BodyString: `foo`,
 				},
@@ -93,8 +93,8 @@ func Test_testRequest(t *testing.T) { //nolint:funlen
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader(`[{"name": "foo"}]`)),
 			},
-			service: &Service{},
-			route: &Route{
+			service: Service{},
+			route: Route{
 				Tester: &Tester{
 					BodyJSON: []map[string]interface{}{
 						{
@@ -145,16 +145,16 @@ func Test_testBodyString(t *testing.T) {
 	data := []struct {
 		title   string
 		req     *http.Request
-		service *Service
-		route   *Route
+		service Service
+		route   Route
 	}{
 		{
 			title: "normal",
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader(`"foo"`)),
 			},
-			service: &Service{},
-			route: &Route{
+			service: Service{},
+			route: Route{
 				Tester: &Tester{
 					BodyString: `"foo"`,
 				},
@@ -163,8 +163,8 @@ func Test_testBodyString(t *testing.T) {
 		{
 			title:   "request body is nil",
 			req:     &http.Request{},
-			service: &Service{},
-			route: &Route{
+			service: Service{},
+			route: Route{
 				Tester: &Tester{
 					BodyString: "",
 				},
@@ -184,8 +184,8 @@ func Test_testPath(t *testing.T) {
 	data := []struct {
 		title   string
 		req     *http.Request
-		service *Service
-		route   *Route
+		service Service
+		route   Route
 	}{
 		{
 			title: "normal",
@@ -194,8 +194,8 @@ func Test_testPath(t *testing.T) {
 					Path: "/foo",
 				},
 			},
-			service: &Service{},
-			route: &Route{
+			service: Service{},
+			route: Route{
 				Tester: &Tester{
 					Path: "/foo",
 				},
@@ -215,16 +215,16 @@ func Test_testMethod(t *testing.T) {
 	data := []struct {
 		title   string
 		req     *http.Request
-		service *Service
-		route   *Route
+		service Service
+		route   Route
 	}{
 		{
 			title: "normal",
 			req: &http.Request{
 				Method: "PUT",
 			},
-			service: &Service{},
-			route: &Route{
+			service: Service{},
+			route: Route{
 				Tester: &Tester{
 					Method: "put",
 				},
@@ -244,16 +244,16 @@ func Test_testBodyJSON(t *testing.T) {
 	data := []struct {
 		title   string
 		req     *http.Request
-		service *Service
-		route   *Route
+		service Service
+		route   Route
 	}{
 		{
 			title: "normal",
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader(`[{"foo":"bar"}]`)),
 			},
-			service: &Service{},
-			route: &Route{
+			service: Service{},
+			route: Route{
 				Tester: &Tester{
 					BodyJSON: []map[string]string{
 						{
@@ -266,8 +266,8 @@ func Test_testBodyJSON(t *testing.T) {
 		{
 			title:   "the request body is nil",
 			req:     &http.Request{},
-			service: &Service{},
-			route: &Route{
+			service: Service{},
+			route: Route{
 				Tester: &Tester{},
 			},
 		},
@@ -285,16 +285,16 @@ func Test_testBodyJSONString(t *testing.T) {
 	data := []struct {
 		title   string
 		req     *http.Request
-		service *Service
-		route   *Route
+		service Service
+		route   Route
 	}{
 		{
 			title: "normal",
 			req: &http.Request{
 				Body: ioutil.NopCloser(strings.NewReader(`[{"foo":"bar"}]`)),
 			},
-			service: &Service{},
-			route: &Route{
+			service: Service{},
+			route: Route{
 				Tester: &Tester{
 					BodyJSONString: `[
 					{"foo":"bar"}
@@ -305,8 +305,8 @@ func Test_testBodyJSONString(t *testing.T) {
 		{
 			title:   "the request body is nil",
 			req:     &http.Request{},
-			service: &Service{},
-			route: &Route{
+			service: Service{},
+			route: Route{
 				Tester: &Tester{},
 			},
 		},
@@ -324,8 +324,8 @@ func Test_testPartOfHeader(t *testing.T) {
 	data := []struct {
 		title   string
 		req     *http.Request
-		service *Service
-		route   *Route
+		service Service
+		route   Route
 	}{
 		{
 			title: "normal",
@@ -335,8 +335,8 @@ func Test_testPartOfHeader(t *testing.T) {
 					"BAR": []string{"bar"},
 				},
 			},
-			service: &Service{},
-			route: &Route{
+			service: Service{},
+			route: Route{
 				Tester: &Tester{
 					Header: http.Header{
 						"FOO": []string{"foo"},
@@ -359,8 +359,8 @@ func Test_testPartOfQuery(t *testing.T) {
 	data := []struct {
 		title   string
 		req     *http.Request
-		service *Service
-		route   *Route
+		service Service
+		route   Route
 	}{
 		{
 			title: "normal",
@@ -369,8 +369,8 @@ func Test_testPartOfQuery(t *testing.T) {
 					RawQuery: "name=foo",
 				},
 			},
-			service: &Service{},
-			route: &Route{
+			service: Service{},
+			route: Route{
 				Tester: &Tester{
 					Query: url.Values{
 						"name": []string{"foo"},

--- a/flute/transport.go
+++ b/flute/transport.go
@@ -26,10 +26,10 @@ body:
 
 // RoundTrip implements http.RoundTripper.
 // RoundTrip traverses the matched route and run the test and returns response.
-func (transport *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+func (transport Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	for _, service := range transport.Services {
 		service := service
-		if !isMatchService(req, &service) {
+		if !isMatchService(req, service) {
 			continue
 		}
 		for _, route := range service.Routes {
@@ -47,7 +47,7 @@ func (transport *Transport) RoundTrip(req *http.Request) (*http.Response, error)
 			}
 			// test
 			if transport.T != nil {
-				testRequest(transport.T, req, &service, &route)
+				testRequest(transport.T, req, service, route)
 			}
 			// return response
 			return createHTTPResponse(req, route.Response)

--- a/flute/transport_test.go
+++ b/flute/transport_test.go
@@ -57,7 +57,7 @@ func TestTransport_RoundTrip(t *testing.T) { //nolint:funlen
 									Method: "POST",
 									Path:   "/users",
 								},
-								Tester: &flute.Tester{
+								Tester: flute.Tester{
 									BodyJSONString: `{
 										  "name": "foo",
 										  "email": "foo@example.com"
@@ -250,7 +250,7 @@ func BenchmarkTransport_RoundTrip(b *testing.B) { //nolint:funlen
 							Method: "POST",
 							Path:   "/users",
 						},
-						Tester: &flute.Tester{
+						Tester: flute.Tester{
 							BodyJSONString: `{
 										  "name": "foo",
 										  "email": "foo@example.com"

--- a/flute/transport_test.go
+++ b/flute/transport_test.go
@@ -19,7 +19,7 @@ func TestTransport_RoundTrip(t *testing.T) { //nolint:funlen
 	data := []struct {
 		title     string
 		req       *http.Request
-		transport *flute.Transport
+		transport flute.Transport
 		isErr     bool
 		exp       *http.Response
 	}{
@@ -37,7 +37,7 @@ func TestTransport_RoundTrip(t *testing.T) { //nolint:funlen
 					"Authorization": []string{"token " + token},
 				},
 			},
-			transport: &flute.Transport{
+			transport: flute.Transport{
 				T: t,
 				Services: []flute.Service{
 					{
@@ -47,13 +47,13 @@ func TestTransport_RoundTrip(t *testing.T) { //nolint:funlen
 						Endpoint: "http://example.com",
 						Routes: []flute.Route{
 							{
-								Matcher: &flute.Matcher{
+								Matcher: flute.Matcher{
 									Method: "GET",
 								},
 							},
 							{
 								Name: "create a user",
-								Matcher: &flute.Matcher{
+								Matcher: flute.Matcher{
 									Method: "POST",
 									Path:   "/users",
 								},
@@ -66,7 +66,7 @@ func TestTransport_RoundTrip(t *testing.T) { //nolint:funlen
 										"Authorization": []string{"token " + token},
 									},
 								},
-								Response: &flute.Response{
+								Response: flute.Response{
 									Base: http.Response{
 										StatusCode: 201,
 									},
@@ -99,13 +99,13 @@ func TestTransport_RoundTrip(t *testing.T) { //nolint:funlen
 					"Authorization": []string{"token " + token},
 				},
 			},
-			transport: &flute.Transport{
+			transport: flute.Transport{
 				Services: []flute.Service{
 					{
 						Endpoint: "http://example.com",
 						Routes: []flute.Route{
 							{
-								Matcher: &flute.Matcher{
+								Matcher: flute.Matcher{
 									Match: func(req *http.Request) (bool, error) {
 										return false, errors.New("failed to match")
 									},
@@ -137,14 +137,14 @@ func TestTransport_RoundTrip(t *testing.T) { //nolint:funlen
 					"Authorization": []string{"token " + token},
 				},
 			},
-			transport: &flute.Transport{
+			transport: flute.Transport{
 				T: t,
 				Services: []flute.Service{
 					{
 						Endpoint: "http://example.com",
 						Routes: []flute.Route{
 							{
-								Matcher: &flute.Matcher{
+								Matcher: flute.Matcher{
 									Match: func(req *http.Request) (bool, error) {
 										return false, errors.New("failed to match")
 									},
@@ -176,13 +176,13 @@ func TestTransport_RoundTrip(t *testing.T) { //nolint:funlen
 					"Authorization": []string{"token " + token},
 				},
 			},
-			transport: &flute.Transport{
+			transport: flute.Transport{
 				Services: []flute.Service{
 					{
 						Endpoint: "http://example.com",
 						Routes: []flute.Route{
 							{
-								Matcher: &flute.Matcher{
+								Matcher: flute.Matcher{
 									Match: func(req *http.Request) (bool, error) {
 										return false, errors.New("failed to match")
 									},
@@ -199,7 +199,7 @@ func TestTransport_RoundTrip(t *testing.T) { //nolint:funlen
 		{
 			title: "transport.Transport is called",
 			req:   &http.Request{},
-			transport: &flute.Transport{
+			transport: flute.Transport{
 				Transport: flute.NewMockRoundTripper(t, gomic.DoNothing).
 					SetReturnRoundTrip(&http.Response{
 						StatusCode: 401,
@@ -231,7 +231,7 @@ func TestTransport_RoundTrip(t *testing.T) { //nolint:funlen
 
 func BenchmarkTransport_RoundTrip(b *testing.B) { //nolint:funlen
 	token := "XXXXX"
-	transport := &flute.Transport{
+	transport := flute.Transport{
 		Services: []flute.Service{
 			{
 				Endpoint: "http://example.org",
@@ -240,13 +240,13 @@ func BenchmarkTransport_RoundTrip(b *testing.B) { //nolint:funlen
 				Endpoint: "http://example.com",
 				Routes: []flute.Route{
 					{
-						Matcher: &flute.Matcher{
+						Matcher: flute.Matcher{
 							Method: "GET",
 						},
 					},
 					{
 						Name: "create a user",
-						Matcher: &flute.Matcher{
+						Matcher: flute.Matcher{
 							Method: "POST",
 							Path:   "/users",
 						},
@@ -259,7 +259,7 @@ func BenchmarkTransport_RoundTrip(b *testing.B) { //nolint:funlen
 								"Authorization": []string{"token " + token},
 							},
 						},
-						Response: &flute.Response{
+						Response: flute.Response{
 							Base: http.Response{
 								StatusCode: 201,
 							},


### PR DESCRIPTION
BREAKING CHNAGE: change the signature of structs

* Improve performance
* Ensure the transport isn't changed

## Benchmark

### Before

https://cloud.drone.io/suzuki-shunsuke/flute/188/1/5

```
Benchmark_isMatchService-48           	14590218	        81.6 ns/op	       0 B/op	       0 allocs/op
--
9 | Benchmark_isMatch/if_mathcer_is_nil,_the_request_matches_the_matcher-48         	339309528	         3.52 ns/op	       0 B/op	       0 allocs/op
10 | Benchmark_isMatch/path_doesn't_match-48                                         	139038411	         8.29 ns/op	       0 B/op	       0 allocs/op
11 | Benchmark_isMatch/method_doesn't_match-48                                       	107690738	        10.9 ns/op	       0 B/op	       0 allocs/op
12 | Benchmark_isMatch/body_string_doesn't_match-48                                  	 4060524	       285 ns/op	     512 B/op	       1 allocs/op
13 | Benchmark_isMatch/body_json_doesn't_match-48                                    	 1000000	      1131 ns/op	     865 B/op	       7 allocs/op
14 | Benchmark_isMatch/body_json_string_doesn't_match-48                             	  863486	      1491 ns/op	     905 B/op	       9 allocs/op
15 | Benchmark_isMatch/header_doesn't_match-48                                       	 2101183	       565 ns/op	      96 B/op	       4 allocs/op
16 | Benchmark_isMatch/header_isn't_equal-48                                         	 6447096	       185 ns/op	       0 B/op	       0 allocs/op
17 | Benchmark_isMatch/query_doesn't_match-48                                        	 1000000	      1148 ns/op	     512 B/op	       7 allocs/op
18 | Benchmark_isMatch/query_isn't_equal-48                                          	 1273093	       976 ns/op	     432 B/op	       4 allocs/op
19 | Benchmark_isMatch/match_function_doesn't_match-48                               	127509306	         9.47 ns/op	       0 B/op	       0 allocs/op
20 | Benchmark_isMatchPartOfQuery/query_value_doesn't_match-48                       	 1000000	      1110 ns/op	     512 B/op	       7 allocs/op
21 | Benchmark_isMatchPartOfQuery/query_isn't_found-48                               	 6947854	       171 ns/op	      48 B/op	       1 allocs/op
22 | Benchmark_isMatchPartOfQuery/query_matches-48                                   	 1020055	      1160 ns/op	     512 B/op	       7 allocs/op
23 | Benchmark_isMatchPartOfHeader/header_value_doesn't_match-48                     	 2085816	       569 ns/op	      96 B/op	       4 allocs/op
24 | Benchmark_isMatchPartOfHeader/header_isn't_found-48                             	23195233	        52.0 ns/op	       0 B/op	       0 allocs/op
25 | Benchmark_isMatchPartOfHeader/header_matches-48                                 	 1913611	       612 ns/op	      96 B/op	       4 allocs/op
26 | Benchmark_isMatchBodyString/request_body_is_nil-48                              	291755187	         4.13 ns/op	       0 B/op	       0 allocs/op
27 | Benchmark_isMatchBodyString/request_body_matches-48                             	 4568509	       291 ns/op	     512 B/op	       1 allocs/op
28 | Benchmark_isMatchBodyString/request_body_doesn't_match-48                       	 3803454	       285 ns/op	     512 B/op	       1 allocs/op
29 | Benchmark_isMatchBodyJSONString/request_body_is_nil-48                          	285607687	         4.12 ns/op	       0 B/op	       0 allocs/op
30 | Benchmark_isMatchBodyJSONString/request_body_json_matches-48                    	  909519	      1402 ns/op	     929 B/op	       9 allocs/op
31 | Benchmark_isMatchBodyJSONString/request_body_json_doesn't_match-48              	  859863	      1422 ns/op	     929 B/op	       9 allocs/op
32 | Benchmark_isMatchBodyJSON/request_body_is_nil-48                                	291765010	         4.11 ns/op	       0 B/op	       0 allocs/op
33 | Benchmark_isMatchBodyJSON/request_body_json_matches-48                          	 1000000	      1032 ns/op	     865 B/op	       7 allocs/op
34 | Benchmark_isMatchBodyJSON/request_body_json_doesn't_match-48                    	 1000000	      1094 ns/op	     865 B/op	       7 allocs/op
35 | Benchmark_createHTTPResponse/body_json_isn't_nil-48                             	  771142	      1608 ns/op	     467 B/op	      11 allocs/op
36 | Benchmark_createHTTPResponse/failed_to_marshal_json-48                          	  717844	      1804 ns/op	     544 B/op	       7 allocs/op
37 | Benchmark_createHTTPResponse/body_string_isn't_nil-48                           	 3136261	       377 ns/op	     193 B/op	       3 allocs/op
38 | Benchmark_createHTTPResponse/nil_request_body-48                                	 3440731	       351 ns/op	     193 B/op	       3 allocs/op
39 | Benchmark_createHTTPResponse/resp.Response-48                                   	 3296454	       383 ns/op	     192 B/op	       3 allocs/op
40 | BenchmarkTransport_RoundTrip-48                                                 	  711099	      1794 ns/op	    1254 B/op	      15 allocs/op
```

### After

https://cloud.drone.io/suzuki-shunsuke/flute/196/1/5

```
Benchmark_isMatchService-48         	16077306	        75.4 ns/op	       0 B/op	       0 allocs/op | 4s
-- | --
9 | Benchmark_isMatch/path_doesn't_match-48         	46152350	        25.9 ns/op	       0 B/op	       0 allocs/op | 6s
10 | Benchmark_isMatch/method_doesn't_match-48       	35202667	        34.0 ns/op	       0 B/op	       0 allocs/op | 7s
11 | Benchmark_isMatch/body_string_doesn't_match-48  	 4100803	       306 ns/op	     512 B/op	       1 allocs/op | 8s
12 | Benchmark_isMatch/body_json_doesn't_match-48    	 1000000	      1098 ns/op	     865 B/op	       7 allocs/op | 9s
13 | Benchmark_isMatch/body_json_string_doesn't_match-48         	  822428	      1452 ns/op	     905 B/op	       9 allocs/op | 11s
14 | Benchmark_isMatch/header_doesn't_match-48                   	 1977729	       608 ns/op	      96 B/op	       4 allocs/op | 13s
15 | Benchmark_isMatch/header_isn't_equal-48                     	 4586121	       262 ns/op	       0 B/op	       0 allocs/op | 14s
16 | Benchmark_isMatch/query_doesn't_match-48                    	  945764	      1115 ns/op	     512 B/op	       7 allocs/op | 15s
17 | Benchmark_isMatch/query_isn't_equal-48                      	 1269537	       940 ns/op	     432 B/op	       4 allocs/op | 17s
18 | Benchmark_isMatch/match_function_doesn't_match-48           	14641996	        81.9 ns/op	       0 B/op	       0 allocs/op | 18s
19 | Benchmark_matchPartOfQuery/query_value_doesn't_match-48     	 1000000	      1004 ns/op	     512 B/op	       7 allocs/op | 19s
20 | Benchmark_matchPartOfQuery/query_isn't_found-48             	 8235597	       148 ns/op	      48 B/op	       1 allocs/op | 21s
21 | Benchmark_matchPartOfQuery/query_matches-48                 	 1000000	      1067 ns/op	     512 B/op	       7 allocs/op | 22s
22 | Benchmark_matchPartOfHeader/header_value_doesn't_match-48   	 2214632	       544 ns/op	      96 B/op	       4 allocs/op | 24s
23 | Benchmark_matchPartOfHeader/header_isn't_found-48           	21893889	        55.3 ns/op	       0 B/op	       0 allocs/op | 25s
24 | Benchmark_matchPartOfHeader/header_matches-48               	 2038860	       584 ns/op	      96 B/op	       4 allocs/op | 27s
25 | Benchmark_matchBodyString/request_body_is_nil-48            	83614329	        14.4 ns/op	       0 B/op	       0 allocs/op | 28s
26 | Benchmark_matchBodyString/request_body_matches-48           	 4412060	       275 ns/op	     512 B/op	       1 allocs/op | 29s
27 | Benchmark_matchBodyString/request_body_doesn't_match-48     	 4413315	       273 ns/op	     512 B/op	       1 allocs/op | 31s
28 | Benchmark_matchBodyJSONString/request_body_is_nil-48        	83645400	        14.3 ns/op	       0 B/op	       0 allocs/op | 32s
29 | Benchmark_matchBodyJSONString/request_body_json_matches-48  	  859090	      1339 ns/op	     929 B/op	       9 allocs/op | 33s
30 | Benchmark_matchBodyJSONString/request_body_json_doesn't_match-48         	  885817	      1386 ns/op	     929 B/op	       9 allocs/op | 35s
31 | Benchmark_matchBodyJSON/request_body_is_nil-48                           	83624607	        14.4 ns/op	       0 B/op	       0 allocs/op | 36s
32 | Benchmark_matchBodyJSON/request_body_json_matches-48                     	 1000000	      1030 ns/op	     865 B/op	       7 allocs/op | 37s
33 | Benchmark_matchBodyJSON/request_body_json_doesn't_match-48               	 1000000	      1030 ns/op	     865 B/op	       7 allocs/op | 38s
34 | Benchmark_createHTTPResponse/body_json_isn't_nil-48                      	  775274	      1564 ns/op	     467 B/op	      11 allocs/op | 39s
35 | Benchmark_createHTTPResponse/failed_to_marshal_json-48                   	  706454	      1704 ns/op	     544 B/op	       7 allocs/op | 40s
36 | Benchmark_createHTTPResponse/body_string_isn't_nil-48                    	 3339332	       359 ns/op	     193 B/op	       3 allocs/op | 42s
37 | Benchmark_createHTTPResponse/nil_request_body-48                         	 3556734	       341 ns/op	     193 B/op	       3 allocs/op | 43s
38 | Benchmark_createHTTPResponse/resp.Response-48                            	 3410667	       352 ns/op	     193 B/op	       3 allocs/op | 45s
39 | BenchmarkTransport_RoundTrip-48                                          	  788850	      1514 ns/op	    1062 B/op	      11 allocs/op
```